### PR TITLE
fixed payment type where it only retrieves payment types added by aut…

### DIFF
--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -104,7 +104,7 @@ class Orders(ViewSet):
         """
         customer = Customer.objects.get(user=request.auth.user)
         order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type = request.data["payment_type"]
+        order.payment_type = Payment.objects.get(pk=request.data["payment_type"])
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -104,7 +104,7 @@ class Orders(ViewSet):
         """
         customer = Customer.objects.get(user=request.auth.user)
         order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type = Payment.objects.get(pk=request.data["payment_type"])
+        order.payment_type = Request.data["payment_type"]
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -81,7 +81,7 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
 
-        customer_id = self.request.query_params.get('customer', None)
+        customer_id = customer_id = self.request.auth.user.id
 
         if customer_id is not None:
             payment_types = payment_types.filter(customer__id=customer_id)


### PR DESCRIPTION
…h user

Description of PR that completes issue here...

## Changes

- Changed ```customer_id = self.request.query_params.get('customer', None)``` to ```customer_id = self.request.auth.user.id```




## Testing

Description of how to test code...

- [ ] go to postman 
- [ ] go to create a payment type
- [ ] under "Body" attempt to create a payment type (merchant, account_number, etc)
- [ ] Unless the Authorization key in header has a token, you should not be able to post payment type


## Related Issues

- Fixes #8
